### PR TITLE
Fix minor error in ETHZ eprog 2019 Ex. 4 Prob. 2

### DIFF
--- a/python_by_contract_corpus/correct/ethz_eprog_2019/exercise_04/problem_02.py
+++ b/python_by_contract_corpus/correct/ethz_eprog_2019/exercise_04/problem_02.py
@@ -14,7 +14,7 @@ from icontract import require, ensure
 # specify what to do if the approximation is numerically not possible.
 @require(lambda c: c < 1000 * 1000)
 @require(lambda eps: eps > 1e-6)
-@ensure(lambda c, eps, result: abs(result * result - c) <= eps, "Guaranteed precision")
+@ensure(lambda c, eps, result: abs(result * result - c) < eps, "Guaranteed precision")
 def approximate_sqrt(c: int, eps: float) -> float:
     """Approximate the square-root of ``c`` up to the precision ``eps``."""
     c_as_float = float(c)


### PR DESCRIPTION
We used less-equal instead of less-than in the contract. Due to the lack of time, we only fix the correct program, but do not add it to the recorded cases.

Fixes #123.